### PR TITLE
Add allowSpecialUseDomain - tough-cookie 4.0.0 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,9 +261,13 @@ FileCookieStore.prototype.findCookie = function(domain, path, key, cb) {
 };
 
 
-FileCookieStore.prototype.findCookies = function (domain, path, cb) {
+FileCookieStore.prototype.findCookies = function (domain, path, allowSpecialUseDomain, cb) {
     var self = this,
         results = [];
+    if (typeof allowSpecialUseDomain === "function") {
+        cb = allowSpecialUseDomain;
+        allowSpecialUseDomain = false;
+    }
     if (! domain ) return cb(null,[]);
     
     var can_domain = canonicalDomain(domain);
@@ -312,7 +316,7 @@ FileCookieStore.prototype.findCookies = function (domain, path, cb) {
             };
         }
         
-        var domains = permuteDomain(can_domain) || [can_domain];
+        var domains = permuteDomain(can_domain, allowSpecialUseDomain) || [can_domain];
         var idx = self.idx;
         domains.forEach(function(curDomain) {
             var domainIndex = idx[curDomain];


### PR DESCRIPTION
Apparently tough-cookie changed the way the `findCookies` method works slightly. It now allows `allowSpecialUseDomain` to be passed, which messes up file-cookie-store when you try to use it since it expects the third argument to be a callback function, causing it to throw an error on any use.

I've actually just copied this new code from tough-cookie's own [memstore.js](https://github.com/salesforce/tough-cookie/blob/master/lib/memstore.js#L61) file. I don't know if this robustly adds tough-cookie 4.0.0 support since I haven't tested it, but I hope it's a start at least.